### PR TITLE
update the new signature of QWidget::nativeEvent method

### DIFF
--- a/QtCustomTitleBar/main.cpp
+++ b/QtCustomTitleBar/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]){
     QApplication a(argc, argv);
     a.setStyle(new QProxyStyle(QStyleFactory::create("Fusion")));
 
-    QFile styleFile("resources/style/appstyles.qss");
+    QFile styleFile(":/recources/style/appstyles.qss");
     styleFile.open(QFile::ReadOnly);
     QString styleQSS = styleFile.readAll();
 

--- a/QtCustomTitleBar/windowframe.cpp
+++ b/QtCustomTitleBar/windowframe.cpp
@@ -109,7 +109,7 @@ void WindowFrame::mouseDoubleClickEvent(QMouseEvent *event) {
 /// @param message Указатель на структуру с информацией о событии (void*).
 /// @param result Указатель на переменную для возвращения результата (long*).
 /// @return Возвращаемое значение, true если событие было обработано, иначе false.
-bool WindowFrame::nativeEvent(const QByteArray &eventType, void *message, long *result) {
+bool WindowFrame::nativeEvent(const QByteArray &eventType, void *message, qintptr *result) {
     Q_UNUSED(eventType)
     MSG *param = static_cast<MSG *>(message);
     switch (param->message){

--- a/QtCustomTitleBar/windowframe.h
+++ b/QtCustomTitleBar/windowframe.h
@@ -40,7 +40,7 @@ protected:
     /// Обработчик события двойного щелчка мыши в окне.
     void mouseDoubleClickEvent(QMouseEvent *event) override;
     /// Обработчик нативного события окна.
-    bool nativeEvent(const QByteArray &eventType, void *message, long *result);
+    bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result);
 public:
     /// Показать или скрыть кнопку минимизации окна.
     void enableMinimum(bool enable);


### PR DESCRIPTION
In Qt 6, the method bool QWidget::nativeEvent(const QByteArray &eventType, void *message, int *result)  is not longer available.
they replace it with bool WindowFrame::nativeEvent(const QByteArray &eventType, void *message, qintptr *result);
the last parameter is no longer `int *result` but , `qintptr *result`.
Also change the path to appstyles.qss. on window 11, `recources/style/appstyles.qss` not working so i replace it with `:/recources/style/appstyles.qss`.
Please try to update your comment, into english so we can collaborate. Thank you.